### PR TITLE
Fix babel config to allow Jest to run

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,10 +1,3 @@
 module.exports = {
-	presets: [
-		[
-			'@babel/preset-env',
-			// '@babel/preset-react',
-			// '@babel/preset-typescript',
-			{ targets: { node: 'current' }, extensions: ['*.ts', '*.tsx'] },
-		],
-	],
+	presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
 };

--- a/src/setup/setup.test.ts
+++ b/src/setup/setup.test.ts
@@ -1,0 +1,9 @@
+import * as Setup from './setup';
+describe('setup functions', () => {
+	it('should set the global variable when passed', () => {
+		const APIKEY = 'HELLO';
+		Setup.BreinifySetup({ apiKey: APIKEY });
+
+		expect(Setup.BreinifyGlobalConfigs.apiKey).toEqual(APIKEY);
+	});
+});


### PR DESCRIPTION
- Fixed babel-plugin syntax to allow for Typescript to run in Jest
- Added example test for setup